### PR TITLE
adding Solaris support

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -19,11 +19,13 @@ class openssh::params {
   $package = $::operatingsystem ? {
     /(?i:SLES|OpenSuSE)/ => 'openssh',
     /(?i:OpenBSD)/       => '',
+    /(?i:Solaris)/       => '',
     default              => 'openssh-server',
   }
 
   $service = $::operatingsystem ? {
     /(?i:Debian|Ubuntu|Mint)/ => 'ssh',
+    /(?i:Solaris)/            => 'ssh',
     default                   => 'sshd',
   }
 
@@ -70,6 +72,7 @@ class openssh::params {
   $config_file_init = $::operatingsystem ? {
     /(?i:Debian|Ubuntu|Mint)/ => '/etc/default/ssh',
     /(?i:OpenBSD)/            => '',
+    /(?i:Solaris)/            => '',
     default                   => '/etc/sysconfig/sshd',
   }
 
@@ -88,6 +91,7 @@ class openssh::params {
   $log_file = $::operatingsystem ? {
     /(?i:Debian|Ubuntu|Mint)/ => '/var/log/syslog',
     /(?i:OpenBSD)/            => '/var/log/authlog',
+    /(?i:Solaris)/            => '/var/adm/authlog',
     default                   => '/var/log/messages',
   }
 


### PR DESCRIPTION
Took the openbsd approach where we don't manage solaris package, only file and service, since the packaging ought to be delivered at install.  Because of this I didn't modify the readme with the site.pp notes.  Mixing Linux and Solaris templates is something of a challenge as the Solaris version does not come with so many nice defaults built in, not sure if we need to make mention of that in the README or not.

Tested on SPARC Solaris 10 and X64 Solaris 10 (vmware).  
